### PR TITLE
Apply EF Core migrations on startup

### DIFF
--- a/Backend/PortfolioWebsite.Api/Program.cs
+++ b/Backend/PortfolioWebsite.Api/Program.cs
@@ -131,6 +131,13 @@ namespace PortfolioWebsite.Api
 
                 app.MapControllers();
 
+                // deploy migrations. We can't do this as part of the build since we're leaving docker and railway to handle them
+                using (var scope = app.Services.CreateScope())
+                {
+                    var db = scope.ServiceProvider.GetRequiredService<SqlDbContext>();
+                    db.Database.Migrate();
+                }
+
                 app.Run();
             }
             catch (Exception ex)


### PR DESCRIPTION
Create a scoped SqlDbContext during app startup and call Database.Migrate() to apply pending EF Core migrations. Ensures the database schema is up-to-date at runtime for deployed environments (cannot be performed during build due to Docker/Railway handling).